### PR TITLE
fix: Lambda function fails because `crhelper` is missing

### DIFF
--- a/lambda/requirements.txt
+++ b/lambda/requirements.txt
@@ -1,1 +1,1 @@
-crhelper
+crhelper==2.0.11

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,10 +133,23 @@ export class AccessKey extends Construct {
       ],
     });
 
+    const bundlingCmds = [
+      'mkdir -p /asset-output',
+      'pip install -r /asset-input/requirements.txt -t /asset-output',
+      'cp index.py /asset-output/index.py',
+    ];
+
     const onEventHandler = new lambda.Function(this, 'OnEventHandler', {
       runtime: lambda.Runtime.PYTHON_3_9,
       handler: 'index.handler',
-      code: props.lambdaCode ?? lambda.Code.fromAsset(path.join(__dirname, '../lambda')),
+      code: props.lambdaCode ?? lambda.Code.fromAsset(path.join(__dirname, '../lambda'), {
+        bundling: {
+          image: lambda.Runtime.PYTHON_3_9.bundlingImage,
+          command: [
+            'bash', '-c', bundlingCmds.join(' && '),
+          ],
+        },
+      }),
       timeout: Duration.seconds(30),
       role,
     });

--- a/test/__snapshots__/accesskey.test.ts.snap
+++ b/test/__snapshots__/accesskey.test.ts.snap
@@ -19,7 +19,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "60689e3966ceea4f3637f40cde716d877a6d2bafcd2b4cb263bb3a4f85174f70.zip",
+          "S3Key": "bc28be0ae267e7a304632531aa839902260d844d367c60aa8dfbe5bf775a3a52.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/test/__snapshots__/accesskey.test.ts.snap
+++ b/test/__snapshots__/accesskey.test.ts.snap
@@ -19,7 +19,7 @@ Object {
           "S3Bucket": Object {
             "Fn::Sub": "cdk-hnb659fds-assets-\${AWS::AccountId}-\${AWS::Region}",
           },
-          "S3Key": "0e26ec1e47d8c68bfd1df421c933491b1ac0e1dc7c7dddf68c78ef7e0a8ec5e0.zip",
+          "S3Key": "60689e3966ceea4f3637f40cde716d877a6d2bafcd2b4cb263bb3a4f85174f70.zip",
         },
         "Handler": "index.handler",
         "Role": Object {

--- a/yarn.lock
+++ b/yarn.lock
@@ -975,9 +975,9 @@
   integrity sha512-JJulVEQXmiY9Px5axXHeYGLSjhkZEnD+MDPDGbCbIAbMslkKwmygtZFy1X6s/075Yo94sf8GuSlFfPzysQrWZQ==
 
 "@types/node@^16":
-  version "16.18.34"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.34.tgz#62d2099b30339dec4b1b04a14c96266459d7c8b2"
-  integrity sha512-VmVm7gXwhkUimRfBwVI1CHhwp86jDWR04B5FGebMMyxV90SlCmFujwUHrxTD4oO+SOYU86SoxvhgeRQJY7iXFg==
+  version "16.18.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.38.tgz#1dcdb6c54d02b323f621213745f2e44af30c73e6"
+  integrity sha512-6sfo1qTulpVbkxECP+AVrHV9OoJqhzCsfTNp5NIG+enM4HyM3HvZCO798WShIXBN0+QtDIcutJCjsVYnQP5rIQ==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"


### PR DESCRIPTION
DEVOPS-354 #comment This was caused by the change to support StackSets which was the only context we were currently using internally. This added the crhelper dependency. We need to make sure this dependency is bundled in all contexts but we only covered the cached code context.